### PR TITLE
Error type

### DIFF
--- a/src/accelerometer.rs
+++ b/src/accelerometer.rs
@@ -1,9 +1,10 @@
 //! Traits for reading acceleration measurements from accelerometers
 
-use crate::reading::Reading;
+use crate::{error::Error, reading::Reading};
+use core::fmt::Debug;
 
 /// Accelerometers capable of obtaining an acceleration reading of type `R`
-pub trait Accelerometer<R: Reading, E> {
+pub trait Accelerometer<R: Reading, E: Debug> {
     /// Get acceleration reading from the accelerometer
-    fn acceleration(&mut self) -> Result<R, E>;
+    fn acceleration(&mut self) -> Result<R, Error<E>>;
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,91 @@
+//! Accelerometer errors - generic over an inner "cause" type (intended to be
+//! an underlying I2C or SPI error type, if applicable)
+
+use core::fmt::{self, Debug, Display};
+
+/// Accelerometer errors, generic around another error type `E` representing
+/// an (optional) cause of this error.
+#[derive(Clone, Debug)]
+pub struct Error<E: Debug> {
+    /// Kind of error which occurred
+    kind: ErrorKind,
+
+    /// Cause of the error (if applicable)
+    cause: Option<E>,
+}
+
+impl<E> Error<E>
+where
+    E: Debug,
+{
+    /// Create a new error
+    pub fn new(kind: ErrorKind) -> Self {
+        Self { kind, cause: None }
+    }
+
+    /// Create a new error with a cause
+    pub fn new_with_cause(kind: ErrorKind, cause: E) -> Self {
+        Self {
+            kind,
+            cause: Some(cause),
+        }
+    }
+
+    /// Create a new error from a cause, e.g. I2C or SPI I/O error
+    pub fn from_cause(cause: E) -> Self {
+        Self::new_with_cause(ErrorKind::Io, cause)
+    }
+
+    /// Get the kind of error which occurred
+    pub fn kind(&self) -> ErrorKind {
+        self.kind
+    }
+
+    /// Get the cause of the underlying error (if applicable)
+    pub fn cause(&self) -> Option<&E> {
+        self.cause.as_ref()
+    }
+
+    /// Convert this error into its underlying cause.
+    ///
+    /// Panics if the error does not have a cause.
+    pub fn into_cause(self) -> E {
+        self.cause
+            .expect("into_cause called on an error with no cause")
+    }
+}
+
+/// Kinds of accelerometer errors
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum ErrorKind {
+    /// Device invalid or other hardware error
+    Device,
+
+    /// I/O error
+    Io,
+}
+
+impl ErrorKind {
+    /// Get a string describing the error
+    pub fn description(self) -> &'static str {
+        match self {
+            ErrorKind::Device => "device error",
+            ErrorKind::Io => "I/O error",
+        }
+    }
+}
+
+impl Display for ErrorKind {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.description())
+    }
+}
+
+impl<E> From<ErrorKind> for Error<E>
+where
+    E: Debug,
+{
+    fn from(kind: ErrorKind) -> Error<E> {
+        Error::new(kind)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,7 @@
 extern crate generic_array;
 
 mod accelerometer;
+pub mod error;
 pub mod reading;
 
 pub use crate::{accelerometer::*, reading::*};


### PR DESCRIPTION
Adds an error type which can capture additional details beyond what is possible with a generic (e.g. I2C or SPI) error type.