### PR TITLE
Basic device tracking support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,22 +2,39 @@
 name = "accelerometer"
 version = "0.2.0"
 dependencies = [
- "generic-array 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libm 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "generic-array 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "heapless 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
+name = "byteorder"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "generic-array"
-version = "0.12.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "typenum 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
-name = "libm"
-version = "0.1.2"
+name = "hash32"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "heapless"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "generic-array 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hash32 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "typenum"
@@ -25,6 +42,8 @@ version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [metadata]
-"checksum generic-array 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3c0f28c2f5bfb5960175af447a2da7c18900693738343dc896ffbcabd9839592"
-"checksum libm 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "03c0bb6d5ce1b5cc6fd0578ec1cbc18c9d88b5b591a5c7c1d6c6175e266a0819"
+"checksum byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a019b10a2a7cdeb292db131fc8113e57ea2a908f6e7894b0c3c671893b65dbeb"
+"checksum generic-array 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8107dafa78c80c848b71b60133954b4a58609a3a1a5f9af037ecc7f67280f369"
+"checksum hash32 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "12d790435639c06a7b798af9e1e331ae245b7ef915b92f70a39b4cf8c00686af"
+"checksum heapless 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "56b960caff1a46f1fb3c1eb05f0575ac21c6248364ebebde11b11116e099881c"
 "checksum typenum 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "612d636f949607bdf9b123b4a6f6d966dedf3ff669f7f045890d3a4a73948169"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,12 @@ categories  = ["embedded", "no-std"]
 keywords    = ["acceleration", "position", "tracking"]
 
 [dependencies]
-generic-array = { version = "0.12", default-features = false }
-libm = "0.1"
+generic-array = { version = "0.11", default-features = false }
+heapless = { version = "0.4", optional = true }
+
+[features]
+default = ["tracking"]
+tracking = ["heapless"]
 
 [badges]
 travis-ci = { repository = "NeoBirth/accelerometer.rs" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,14 +7,13 @@
 #![no_std]
 #![deny(
     warnings,
+    unsafe_code,
     missing_docs,
     trivial_casts,
     trivial_numeric_casts,
-    unsafe_code,
     unused_import_braces,
     unused_qualifications
 )]
-#![forbid(unsafe_code)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/NeoBirth/accelerometer.rs/master/img/cartesian-ferris.png",
     html_root_url = "https://docs.rs/accelerometer/0.2.0"
@@ -25,6 +24,11 @@ extern crate generic_array;
 
 mod accelerometer;
 pub mod error;
+mod math;
+#[cfg(feature = "tracking")]
+pub mod tracking;
 pub mod vector;
 
+#[cfg(feature = "tracking")]
+pub use crate::tracking::*;
 pub use crate::{accelerometer::*, error::*, vector::*};

--- a/src/math.rs
+++ b/src/math.rs
@@ -1,0 +1,79 @@
+//! Floating point operations which would ordinarily be provided by `std`
+//! but aren't available in `no_std`.
+
+use core::mem;
+
+/// `std`-like extension methods for math support
+pub(crate) trait F32Ext: Sized {
+    fn sqrt(self) -> Self;
+}
+
+impl F32Ext for f32 {
+    /// Square root approximation
+    fn sqrt(self) -> Self {
+        sqrt_approx(self)
+    }
+}
+
+/// Square root approximation function for a single-precision float.
+/// Separated from `F32Ext` in order to make it easier to test.
+fn sqrt_approx(n: f32) -> f32 {
+    #[allow(unsafe_code)]
+    let mut n: u32 = unsafe { mem::transmute(n) };
+    n += 127 << 23;
+    n >>= 1;
+    f32::from_bits(n)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::sqrt_approx;
+
+    /// Square root test vectors
+    const SQRT_TEST_VECTORS: &[(f32, f32)] = &[
+        (1.0, 1.0),
+        (2.0, 1.414),
+        (3.0, 1.732),
+        (4.0, 2.0),
+        (5.0, 2.236),
+        (6.0, 2.449),
+        (7.0, 2.645),
+        (8.0, 2.828),
+        (9.0, 3.0),
+        (10.0, 3.162),
+        (100.0, 10.0),
+        (250.0, 15.811),
+        (500.0, 22.36),
+        (1000.0, 31.622),
+        (2500.0, 50.0),
+        (5000.0, 70.710),
+        (10000.0, 100.0),
+        (25000.0, 158.113),
+        (50000.0, 223.606),
+        (100000.0, 316.227),
+        (250000.0, 500.0),
+        (500000.0, 707.106),
+        (1000000.0, 1000.0),
+        (2500000.0, 1581.138),
+        (5000000.0, 2236.067),
+        (10000000.0, 3162.277),
+        (25000000.0, 5000.0),
+        (50000000.0, 7071.067),
+        (100000000.0, 10000.0),
+    ];
+
+    #[test]
+    fn sqrt_approx_test() {
+        for (n, n_sqrt) in SQRT_TEST_VECTORS {
+            let allowed_delta = n * 0.05;
+            let actual_delta = sqrt_approx(*n) - n_sqrt;
+            assert!(
+                actual_delta <= allowed_delta,
+                "delta {} too large: {} vs {}",
+                actual_delta,
+                sqrt_approx(*n),
+                n_sqrt
+            );
+        }
+    }
+}

--- a/src/tracking/mod.rs
+++ b/src/tracking/mod.rs
@@ -1,0 +1,8 @@
+//! Device position tracking which uses statistical methods to filter noisy
+//! accelerometer data (moving average computed from a trimmed mean with
+//! outliers culled).
+
+mod samples;
+mod tracker;
+
+pub use self::{samples::Samples, tracker::*};

--- a/src/tracking/samples.rs
+++ b/src/tracking/samples.rs
@@ -1,0 +1,153 @@
+//! Collection of acceleration data samples with support for performing
+//! various kinds of statistical analysis on them.
+
+#[allow(unused_imports)]
+use crate::math::F32Ext;
+use crate::vector::Vector;
+use core::slice;
+use generic_array::ArrayLength;
+use heapless::Vec;
+
+/// Ring buffer for accelerometer data samples
+#[derive(Clone)]
+pub struct Samples<V, L>
+where
+    V: Vector,
+    L: ArrayLength<V>,
+{
+    /// Internal sample buffer
+    buffer: Vec<V, L>,
+
+    /// Position within our internal sample buffer
+    position: usize,
+}
+
+impl<V, L> Samples<V, L>
+where
+    V: Vector,
+    L: ArrayLength<V>,
+{
+    /// Create an empty set of samples
+    pub fn new() -> Self {
+        Self {
+            buffer: Vec::new(),
+            position: 0,
+        }
+    }
+
+    /// Update the internal sample buffer with the given sample
+    pub fn update(&mut self, sample: V) {
+        if self.buffer.len() < L::to_usize() {
+            // In this case, we haven't yet filled the internal buffer
+            self.buffer.push(sample).unwrap();
+        } else {
+            self.buffer[self.position] = sample;
+        }
+
+        self.position = (self.position + 1) % L::to_usize();
+    }
+
+    /// Compute arithmetic mean of the components of an iterator over vectors,
+    /// returning a vector consisting of the arithmetic means of its components.
+    ///
+    /// This method does not cull outliers.
+    pub fn mean(&self) -> V {
+        V::mean(self.buffer.iter().cloned())
+    }
+
+    /// Compute a "trimmed" mean which culls outliers before computing the mean.
+    /// This should hopefully help reduce noise from the accelerometer data.
+    pub fn trimmed_mean(&self) -> V {
+        V::mean(self.iter_trimmed())
+    }
+
+    /// Iterate over the raw samples currently in the buffer.
+    ///
+    /// Iteration order is presently not necessarily correlated to recency.
+    pub fn iter(&self) -> slice::Iter<V> {
+        self.buffer.iter()
+    }
+
+    /// Create a "trimmed" iterator which skips over statistical outliers
+    pub fn iter_trimmed(&self) -> IterTrimmed<V> {
+        IterTrimmed::new(self)
+    }
+}
+
+impl<V, L> AsRef<[V]> for Samples<V, L>
+where
+    V: Vector,
+    L: ArrayLength<V>,
+{
+    fn as_ref(&self) -> &[V] {
+        self.buffer.as_ref()
+    }
+}
+
+impl<V, L> Default for Samples<V, L>
+where
+    V: Vector,
+    L: ArrayLength<V>,
+{
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// A "trimmed" iterator over the sample buffer which skips outliers
+pub struct IterTrimmed<'a, V: Vector> {
+    /// Iterator over the underlying sample buffer
+    samples: slice::Iter<'a, V>,
+
+    /// Arithmetic mean the sample vectors as a vector
+    mean: V,
+
+    /// Standard deviation of the distance from the mean
+    stddev: f32,
+}
+
+impl<'a, V> IterTrimmed<'a, V>
+where
+    V: Vector,
+{
+    /// Create a new trimmed iterator from a set of samples
+    fn new<L>(samples: &'a Samples<V, L>) -> Self
+    where
+        L: ArrayLength<V>,
+    {
+        let mean = samples.mean();
+        let mut sum = 0.0;
+
+        for sample in samples.iter() {
+            let n = sample.distance(mean);
+            sum += n * n;
+        }
+
+        let variance = sum / (L::to_usize() as f32 - 1.0);
+        let stddev = variance.sqrt();
+
+        Self {
+            samples: samples.iter(),
+            mean,
+            stddev,
+        }
+    }
+}
+
+impl<'a, V> Iterator for IterTrimmed<'a, V>
+where
+    V: Vector,
+{
+    type Item = V;
+
+    fn next(&mut self) -> Option<V> {
+        while let Some(sample) = self.samples.next() {
+            // TODO(tarcieri): better method for finding outliers? (e.g. MAD, IQD)
+            if (sample.distance(self.mean) / self.stddev) < 3.0 {
+                return Some(*sample);
+            }
+        }
+
+        None
+    }
+}

--- a/src/tracking/tracker.rs
+++ b/src/tracking/tracker.rs
@@ -1,0 +1,86 @@
+//! Device position tracker which uses a sliding widow of acceleration data
+//! samples to help filter the signal from the noise.
+
+use super::samples::Samples;
+use crate::{accelerometer::Accelerometer, error::Error, vector::Vector};
+use core::{fmt::Debug, marker::PhantomData};
+use generic_array::{
+    typenum::{U16, U32},
+    ArrayLength,
+};
+
+/// Alias for a `Tracker` with a 16-sample buffer
+pub type Tracker16<A, V, E> = Tracker<A, V, E, U16>;
+
+/// Alias for a `Tracker` with a 32-sample buffer
+pub type Tracker32<A, V, E> = Tracker<A, V, E, U32>;
+
+/// Device position tracker which which filters noisy accelerometer data
+/// using statistical methods
+pub struct Tracker<A, V, E, L>
+where
+    A: Accelerometer<V, E>,
+    V: Vector,
+    E: Debug,
+    L: ArrayLength<V>,
+{
+    /// The underlying accelerometer device
+    accelerometer: A,
+
+    /// Samples of accelerometer data
+    samples: Samples<V, L>,
+
+    /// Error type associated with the underlying accelerometer
+    errors: PhantomData<E>,
+}
+
+impl<A, V, E, S> Tracker<A, V, E, S>
+where
+    A: Accelerometer<V, E>,
+    V: Vector,
+    E: Debug,
+    S: ArrayLength<V>,
+{
+    /// Create a new device position tracker for the given accelerometer
+    pub fn new(accelerometer: A) -> Self {
+        Self {
+            accelerometer,
+            samples: Samples::new(),
+            errors: PhantomData,
+        }
+    }
+
+    /// Borrow the underlying accelerometer device
+    pub fn accelerometer(&self) -> &A {
+        &self.accelerometer
+    }
+
+    /// Consume `self` and return the underlying accelerometer
+    pub fn into_accelerometer(self) -> A {
+        self.accelerometer
+    }
+
+    /// Borrow the underlying buffer of `Samples`
+    pub fn samples(&self) -> &Samples<V, S> {
+        &self.samples
+    }
+
+    /// Read a sample from the underlying device and store it in the internal
+    /// sample buffer
+    pub fn update(&mut self) -> Result<V, Error<E>> {
+        let sample = self.accelerometer.acceleration()?;
+        self.samples.update(sample);
+        Ok(sample)
+    }
+
+    /// Obtain a moving average (trimmed mean) of the current accelerometer data
+    /// (after culling outliers).
+    ///
+    /// When called, this method will call `Tracker::update` to take a sample
+    /// of accelerometer data first. To avoid this, call `Tracker::samples`
+    /// and invoke the `mean()` function on the underlying buffer.
+    pub fn mean_acceleration(&mut self) -> Result<V, Error<E>> {
+        self.update()?;
+        Ok(self.samples.trimmed_mean())
+    }
+}

--- a/src/vector.rs
+++ b/src/vector.rs
@@ -1,6 +1,8 @@
 //! Algebraic vector types generic over a number of axes and a component type,
 //! useful for representing accelerometer data or values computed from it.
 
+#[allow(unused_imports)]
+use crate::math::F32Ext;
 use core::{
     fmt::Debug,
     ops::{Add, Div, Index, Mul, MulAssign, Sub},
@@ -9,10 +11,6 @@ use generic_array::{
     typenum::{Unsigned, U2, U3},
     ArrayLength, GenericArray,
 };
-
-// rustc complains this is unused even though it's used! possible rustc bug?
-#[allow(unused_imports)]
-use libm::F32Ext;
 
 /// Maximum number of axes we presently support
 // TODO(tarcieri): replace this with better use of `generic-array` or const generics
@@ -114,7 +112,7 @@ pub trait Vector:
             .sqrt()
     }
 
-    /// Obtain an array of the vector components
+    /// Obtain an array of the acceleration components for each of the axes
     fn to_array(self) -> GenericArray<Self::Component, Self::Axes>;
 }
 


### PR DESCRIPTION
Adds support for keeping a history of accelerometer samples, applying some basic statistical methods to them (outlier culling), and computing mean and trimmed mean acceleration.

This commit also removes the `libm` crate. It seems it's un(der)maintained and full of overflow bugs. We're only using one function from it at the moment (`sqrt`) so we can just implement that for now.