### PR TITLE
Orientation enum

### DIFF
--- a/src/tracking/mod.rs
+++ b/src/tracking/mod.rs
@@ -2,7 +2,8 @@
 //! accelerometer data (moving average computed from a trimmed mean with
 //! outliers culled).
 
+mod orientation;
 mod samples;
 mod tracker;
 
-pub use self::{samples::Samples, tracker::*};
+pub use self::{orientation::*, samples::Samples, tracker::*};

--- a/src/tracking/orientation.rs
+++ b/src/tracking/orientation.rs
@@ -1,0 +1,50 @@
+/// Device orientation as computed from accelerometer data
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum Orientation {
+    /// Unable to determine the orientation from current data
+    Unknown,
+
+    /// Device is in portrait mode in whatever way is considered "up"
+    PortraitUp,
+
+    /// Device is in portrait mode in whatever way is considered "down"
+    PortraitDown,
+
+    /// Device is in landscape mode in whatever way is considered "up"
+    LandscapeUp,
+
+    /// Device is in landscape mode in whatever way is considered "down"
+    LandscapeDown,
+
+    /// Device is parallel to the ground, facing up
+    FaceUp,
+
+    /// Device is parallel to the ground, facing down
+    FaceDown,
+}
+
+impl Orientation {
+    /// Is this orientation considered to be flat?
+    pub fn is_flat(self) -> bool {
+        match self {
+            Orientation::FaceUp | Orientation::FaceDown => true,
+            _ => false,
+        }
+    }
+
+    /// Is the device in a landscape orientation?
+    pub fn is_landscape(self) -> bool {
+        match self {
+            Orientation::LandscapeUp | Orientation::LandscapeDown => true,
+            _ => false,
+        }
+    }
+
+    /// Is the device in a portrait orientation?
+    pub fn is_portrait(self) -> bool {
+        match self {
+            Orientation::PortraitUp | Orientation::PortraitDown => true,
+            _ => false,
+        }
+    }
+}


### PR DESCRIPTION
Adds an `Orientation` enum which provides coarse-grained information about a device's orientation as sensed by the accelerometer.

Not presently wired up to anything, but useful as a common output type for functions which compute this information.