### PR TITLE
v0.5.2

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+## [0.5.2] (2019-05-03)
+
+- `lib.rs`: Add docs on writing an accelerometer driver ([#24])
+- `lib.rs`: Fix `html_logo_url` to point at `develop` branch ([#23])
+
 ## [0.5.1] (2019-05-03)
 
 - Update to micromath v0.2 ([#20])
@@ -26,6 +31,9 @@
 
 - Initial implementation ([#1])
 
+[0.5.2]: https://github.com/NeoBirth/accelerometer.rs/pull/25
+[#24]: https://github.com/NeoBirth/accelerometer.rs/pull/24
+[#23]: https://github.com/NeoBirth/accelerometer.rs/pull/23
 [0.5.1]: https://github.com/NeoBirth/accelerometer.rs/pull/21
 [#20]: https://github.com/NeoBirth/accelerometer.rs/pull/20
 [0.5.0]: https://github.com/NeoBirth/accelerometer.rs/pull/19

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ description = """
               traits and types for taking readings from 2 or 3-axis
               accelerometers and tracking device orientations.
               """
-version     = "0.5.1"
+version     = "0.5.2"
 authors     = ["Tony Arcieri <bascule@gmail.com>"]
 license     = "Apache-2.0 OR MIT"
 homepage    = "https://neobirth.org"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,7 +39,7 @@
 #![forbid(unsafe_code)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/NeoBirth/accelerometer.rs/develop/img/cartesian-ferris.png",
-    html_root_url = "https://docs.rs/accelerometer/0.5.1"
+    html_root_url = "https://docs.rs/accelerometer/0.5.2"
 )]
 
 mod accelerometer;


### PR DESCRIPTION
- `lib.rs`: Add docs on writing an accelerometer driver (#24)
- `lib.rs`: Fix `html_logo_url` to point at `develop` branch (#23)