### PR TITLE
Decouple `Tracker` from `Accelerometer`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,6 @@ description = """
 version     = "0.7.0"
 authors     = ["Tony Arcieri <bascule@gmail.com>"]
 license     = "Apache-2.0 OR MIT"
-homepage    = "https://neobirth.org"
 repository  = "https://github.com/NeoBirth/accelerometer.rs"
 readme      = "README.md"
 edition     = "2018"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,10 +15,10 @@
 //! and write a driver which is able to communicate with the accelerometer and
 //! obtain data.
 //!
-//! Next, impl the [Accelerometer] trait for your driver. You will need to
-//! choose a [Vector] type for representing accelerometer data which best
+//! Next, impl the [`Accelerometer`] trait for your driver. You will need to
+//! choose a [`Vector`] type for representing accelerometer data which best
 //! matches the output of your device. This trait has a single method,
-//! [acceleration], which returns a reading from the accelerometer or an error.
+//! [`Accelerometer::acceleration`], which returns a reading from the accelerometer or an error.
 //!
 //! See the [ADXL343 crate] for an example.
 //!


### PR DESCRIPTION
The main tracker API is changed to `Tracker::update`, which takes an acceleration vector, rather than having the tracker own the accelerometer.