### PR TITLE
Split `Accelerometer` and `RawAccelerometer`

### DIFF
--- a/src/accelerometer.rs
+++ b/src/accelerometer.rs
@@ -1,21 +1,35 @@
-//! Traits for reading acceleration measurements from accelerometers
+//! Traits for reading acceleration measurements from accelerometers.
 
+use crate::{
+    error::Error,
+    vector::{F32x3, Vector},
+};
 use core::fmt::Debug;
-use micromath::vector::{F32x3, Vector};
 
-/// Accelerometers which measure acceleration vectors of type `V`
-pub trait Accelerometer<V: Vector> {
+/// Accelerometer trait which provides g-normalized readings.
+pub trait Accelerometer {
+    /// Error type
+    type Error: Debug;
+
+    /// Get normalized ±g reading from the accelerometer.
+    ///
+    /// Ex. {0.0, 5.2, 0.0} - 5.2 g of acceleration in the y-axis
+    fn accel_norm(&mut self) -> Result<F32x3, Error<Self::Error>>;
+
+    /// Get sample rate of accelerometer data.
+    ///
+    /// Ex. 125.0 - sample rate of 125hz
+    fn sample_rate(&mut self) -> Result<f32, Error<Self::Error>>;
+}
+
+/// Read raw acceleration vectors of type `V: Vector`.
+///
+/// This is intended to provide direct access to raw accelerometer data and
+/// should use a vector type which best matches the raw accelerometer data.
+pub trait RawAccelerometer<V: Vector> {
     /// Error type
     type Error: Debug;
 
     /// Get raw acceleration data from the accelerometer
-    fn accel_raw(&mut self) -> Result<V, Self::Error>;
-
-    /// Get normalized acceleration data from the accelerometer
-    /// Ex. {0.0, 5.2, 0.0} - 5.2 G's of acceleration in the y-axis
-    fn accel_norm(&mut self) -> Result<F32x3, Self::Error>;
-
-    /// Get sample rate of accelerometer data
-    /// Ex. 125.0 - sample rate of 125hz
-    fn sample_rate(&mut self) -> Result<f32, Self::Error>;
+    fn accel_raw(&mut self) -> Result<V, Error<Self::Error>>;
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,5 @@
 //! Accelerometer errors - generic over an inner "cause" type (intended to be
-//! an underlying I2C or SPI error type, if applicable)
+//! an underlying I2C or SPI error type, if applicable).
 
 use core::fmt::{self, Debug, Display};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,10 +15,14 @@
 //! and write a driver which is able to communicate with the accelerometer and
 //! obtain data.
 //!
-//! Next, impl the [`Accelerometer`] trait for your driver. You will need to
-//! choose a [`Vector`] type for representing accelerometer data which best
-//! matches the output of your device. This trait has a single method,
-//! [`Accelerometer::acceleration`], which returns a reading from the accelerometer or an error.
+//! Next, impl the [`Accelerometer`] trait (providing normalized readings) and/or
+//! the [`RawAccelerometer`] trait (providing direct access to raw data) for
+//! your driver (ideally the former, as it provides reuse across drivers).
+//!
+//! For [`RawAccelerometer`], you will need to choose a [`Vector`] type for
+//! raw accelerometer data which best matches the output of your device.
+//! This trait has a single method, [`RawAccelerometer::accel_raw`], which
+//! returns a reading from the accelerometer or an error.
 //!
 //! See the [ADXL343 crate] for an example.
 //!
@@ -40,7 +44,8 @@ pub mod error;
 #[cfg(feature = "orientation")]
 pub mod orientation;
 
+pub use crate::{accelerometer::*, error::*};
+pub use micromath::vector::{self, Vector};
+
 #[cfg(feature = "orientation")]
 pub use crate::orientation::*;
-pub use crate::{accelerometer::*, error::*};
-pub use micromath::vector::{self, *};

--- a/src/orientation.rs
+++ b/src/orientation.rs
@@ -1,4 +1,4 @@
-//! Orientation tracking for accelerometer-equipped devices
+//! Orientation tracking for accelerometer-equipped devices.
 
 mod tracker;
 

--- a/src/orientation/tracker.rs
+++ b/src/orientation/tracker.rs
@@ -33,8 +33,8 @@ impl Tracker {
     /// strong reading from one axis alone). It may require some
     /// experimentation to properly tune this threshold.
     ///
-    /// For best results, set the accelerometer's sensitivity higher than ±2G,
-    /// e.g. ±4G or ±8G. This will help reduce noise in the accelerometer data.
+    /// For best results, set the accelerometer's sensitivity higher than ±2g,
+    /// e.g. ±4g or ±8g. This will help reduce noise in the accelerometer data.
     pub fn new(threshold: impl Into<f32>) -> Self {
         Self {
             threshold: threshold.into(),
@@ -43,7 +43,7 @@ impl Tracker {
     }
 
     /// Update the tracker's internal state from the given acceleration vector
-    /// (i.e. obtained from [`Accelerometer::acceleration`]), returning a new
+    /// (i.e. obtained from [`Accelerometer::accel_norm`]), returning a new
     /// computed orientation value.
     pub fn update<V, C>(&mut self, acceleration: V) -> Orientation
     where


### PR DESCRIPTION
Some accelerometers (e.g. ADXL343) support reading raw acceleration in e.g. both integer and floating point format, and for this reason it may make sense to impl the raw acceleration trait repeatedly for different vector types (which the `adxl343` crate presently does).

However, for normalized acceleration, this doesn't make sense and the impls could potentially conflict as the type system has no generic parameters to resolve which trait impl to use.

This commit splits the `Accelerometer` trait into a separate `RawAccelerometer` trait providing something closer to the previous API which can be impl'd many times for different types of raw readings.