### PR TITLE
v0.11.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,95 +1,113 @@
-## [0.10.0] (2019-12-02)
+# Changelog
+All notable changes to this project will be documented in this file.
 
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## 0.11.0 (2020-01-23)
+### Changed
+- Split `Accelerometer` and `RawAccelerometer` ([#53], [#54])
+- Move vector types under `accelerometer::vector::*` ([#54])
+- Use `accelerometer::Error` in (Raw)`Accelerometer` API ([#54])
+
+[#53]: https://github.com/NeoBirth/accelerometer.rs/pull/53
+[#54]: https://github.com/NeoBirth/accelerometer.rs/pull/54
+
+## 0.10.0 (2019-12-02)
+### Changed
 - Upgrade to `micromath` v1.0 ([#48])
 
-## [0.9.0] (2019-11-14)
+[#48]: https://github.com/NeoBirth/accelerometer.rs/pull/48
 
+## 0.9.0 (2019-11-14)
+### Changed
 - Upgrade to `micromath` v0.5 ([#45])
 
-## [0.8.1] (2019-11-01)
+[#45]: https://github.com/NeoBirth/accelerometer.rs/pull/45
 
+## 0.8.1 (2019-11-01)
+### Fixed
 - Fix doc link resolution failure ([#40])
 
-## [0.8.0] (2019-11-01)
+[#40]: https://github.com/NeoBirth/accelerometer.rs/pull/40
 
+## 0.8.0 (2019-11-01)
+### Changed
 - Decouple `Tracker` from `Accelerometer` ([#38])
 
-## [0.7.0] (2019-10-02)
+[#38]: https://github.com/NeoBirth/accelerometer.rs/pull/38
 
+## 0.7.0 (2019-10-02)
+### Changed
 - Upgrade to `micromath` v0.4 ([#34])
 
-## [0.6.1] (2019-09-26)
+[#34]: https://github.com/NeoBirth/accelerometer.rs/pull/34
 
+## 0.6.1 (2019-09-26)
+### Changed
 - README updates ([#30], [#32])
 
-## [0.6.0] (2019-05-04)
+[#30]: https://github.com/NeoBirth/accelerometer.rs/pull/30
+[#32]: https://github.com/NeoBirth/accelerometer.rs/pull/32
 
+## 0.6.0 (2019-05-04)
+### Changed
 - Update to micromath v0.3 ([#28])
 
-## [0.5.2] (2019-05-03)
+[#28]: https://github.com/NeoBirth/accelerometer.rs/pull/28
 
+## 0.5.2 (2019-05-03)
+### Added
 - `lib.rs`: Add docs on writing an accelerometer driver ([#24])
+
+### Fixed
 - `lib.rs`: Fix `html_logo_url` to point at `develop` branch ([#23])
 
-## [0.5.1] (2019-05-03)
+[#23]: https://github.com/NeoBirth/accelerometer.rs/pull/23
+[#24]: https://github.com/NeoBirth/accelerometer.rs/pull/24
 
+## 0.5.1 (2019-05-03)
+### Changed
 - Update to micromath v0.2 ([#20])
 
-## [0.5.0] (2019-05-03)
+[#20]: https://github.com/NeoBirth/accelerometer.rs/pull/20
 
+## 0.5.0 (2019-05-03)
+### Changed
 - Use the `micromath` crate ([#18])
 
-## [0.4.0] (2019-04-04)
+[#18]: https://github.com/NeoBirth/accelerometer.rs/pull/18
 
+## 0.4.0 (2019-04-04)
+### Added
 - Add a `Component` trait for vector components ([#16])
+
+### Changed
 - Simplified orientation tracker ([#15])
 - Refactor `vector` module ([#13])
 
-## [0.3.0] (2019-03-31)
+[#13]: https://github.com/NeoBirth/accelerometer.rs/pull/13
+[#15]: https://github.com/NeoBirth/accelerometer.rs/pull/15
+[#16]: https://github.com/NeoBirth/accelerometer.rs/pull/16
 
+## 0.3.0 (2019-03-31)
+### Added
 - `Orientation` enum ([#11])
 - Basic device tracking support ([#6])
 
-## [0.2.0] (2019-03-26)
+[#6]: https://github.com/NeoBirth/accelerometer.rs/pull/6
+[#11]: https://github.com/NeoBirth/accelerometer.rs/pull/11
 
+## 0.2.0 (2019-03-26)
+### Added
 - Vector types ([#7])
 - Error type ([#5])
 
-## [0.1.0] (2019-03-24)
+[#5]: https://github.com/NeoBirth/accelerometer.rs/pull/5
+[#7]: https://github.com/NeoBirth/accelerometer.rs/pull/7
 
+## 0.1.0 (2019-03-24)
+### Added
 - Initial implementation ([#1])
 
-[0.10.0]: https://github.com/NeoBirth/accelerometer.rs/pull/49
-[#48]: https://github.com/NeoBirth/accelerometer.rs/pull/48
-[0.9.0]: https://github.com/NeoBirth/accelerometer.rs/pull/46
-[#45]: https://github.com/NeoBirth/accelerometer.rs/pull/45
-[0.8.1]: https://github.com/NeoBirth/accelerometer.rs/pull/41
-[#40]: https://github.com/NeoBirth/accelerometer.rs/pull/40
-[0.8.0]: https://github.com/NeoBirth/accelerometer.rs/pull/39
-[#38]: https://github.com/NeoBirth/accelerometer.rs/pull/38
-[0.7.0]: https://github.com/NeoBirth/accelerometer.rs/pull/35
-[#34]: https://github.com/NeoBirth/accelerometer.rs/pull/34
-[0.6.1]: https://github.com/NeoBirth/accelerometer.rs/pull/33
-[#32]: https://github.com/NeoBirth/accelerometer.rs/pull/32
-[#30]: https://github.com/NeoBirth/accelerometer.rs/pull/30
-[0.6.0]: https://github.com/NeoBirth/accelerometer.rs/pull/29
-[#28]: https://github.com/NeoBirth/accelerometer.rs/pull/28
-[0.5.2]: https://github.com/NeoBirth/accelerometer.rs/pull/25
-[#24]: https://github.com/NeoBirth/accelerometer.rs/pull/24
-[#23]: https://github.com/NeoBirth/accelerometer.rs/pull/23
-[0.5.1]: https://github.com/NeoBirth/accelerometer.rs/pull/21
-[#20]: https://github.com/NeoBirth/accelerometer.rs/pull/20
-[0.5.0]: https://github.com/NeoBirth/accelerometer.rs/pull/19
-[#18]: https://github.com/NeoBirth/accelerometer.rs/pull/18
-[0.4.0]: https://github.com/NeoBirth/accelerometer.rs/pull/17
-[#16]: https://github.com/NeoBirth/accelerometer.rs/pull/16
-[#15]: https://github.com/NeoBirth/accelerometer.rs/pull/15
-[#13]: https://github.com/NeoBirth/accelerometer.rs/pull/13
-[0.3.0]: https://github.com/NeoBirth/accelerometer.rs/pull/12
-[#11]: https://github.com/NeoBirth/accelerometer.rs/pull/11
-[#6]: https://github.com/NeoBirth/accelerometer.rs/pull/6
-[0.2.0]: https://github.com/NeoBirth/accelerometer.rs/pull/9
-[#7]: https://github.com/NeoBirth/accelerometer.rs/pull/7
-[#5]: https://github.com/NeoBirth/accelerometer.rs/pull/5
-[0.1.0]: https://github.com/NeoBirth/accelerometer.rs/pull/2
 [#1]: https://github.com/NeoBirth/accelerometer.rs/pull/1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "accelerometer"
-version     = "0.10.0" # Also update html_root_url in lib.rs when bumping this
+version     = "0.11.0" # Also update html_root_url in lib.rs when bumping this
 description = """
 Generic, embedded-friendly accelerometer support, including
 traits and types for taking readings from 2 or 3-axis

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ For more information, please see [CODE_OF_CONDUCT.md].
 
 ## License
 
-Copyright © 2019 NeoBirth Developers
+Copyright © 2019-2020 NeoBirth Developers
 
 Dual licensed under your choice of either of:
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,7 +34,7 @@
 #![no_std]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/NeoBirth/accelerometer.rs/develop/img/cartesian-ferris.png",
-    html_root_url = "https://docs.rs/accelerometer/0.10.0"
+    html_root_url = "https://docs.rs/accelerometer/0.11.0"
 )]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]


### PR DESCRIPTION
### Changed
- Split `Accelerometer` and `RawAccelerometer` ([#53], [#54])
- Move vector types under `accelerometer::vector::*` ([#54])
- Use `accelerometer::Error` in (Raw)`Accelerometer` API ([#54])

[#53]: https://github.com/NeoBirth/accelerometer.rs/pull/53
[#54]: https://github.com/NeoBirth/accelerometer.rs/pull/54