### PR TITLE
v0.12.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.12.0 (2020-06-13)
+### Fixed
+- `orientation::Tracker` handling of z-orientation ([#58])
+
+[#58]: https://github.com/NeoBirth/accelerometer.rs/pull/58
+
 ## 0.11.0 (2020-01-23)
 ### Changed
 - Split `Accelerometer` and `RawAccelerometer` ([#53], [#54])

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "accelerometer"
-version     = "0.11.0" # Also update html_root_url in lib.rs when bumping this
+version     = "0.12.0" # Also update html_root_url in lib.rs when bumping this
 description = """
 Generic, embedded-friendly accelerometer support, including
 traits and types for taking readings from 2 or 3-axis

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,7 +34,7 @@
 #![no_std]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/NeoBirth/accelerometer.rs/develop/img/cartesian-ferris.png",
-    html_root_url = "https://docs.rs/accelerometer/0.11.0"
+    html_root_url = "https://docs.rs/accelerometer/0.12.0"
 )]
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]


### PR DESCRIPTION
### Fixed
- `orientation::Tracker` handling of z-orientation ([#58])

[#58]: https://github.com/NeoBirth/accelerometer.rs/pull/58