### PR TITLE
Upgrade to `micromath` v2.0

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       matrix:
         toolchain:
-          - 1.31.0
+          - 1.47.0
           - stable
     steps:
       - name: Checkout sources
@@ -69,7 +69,7 @@ jobs:
     strategy:
       matrix:
         toolchain:
-          - 1.31.0
+          - 1.47.0
           - stable
     steps:
       - name: Checkout sources

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ keywords    = ["acceleration", "position", "tracking"]
 maintenance = { status = "passively-maintained" }
 
 [dependencies.micromath]
-version = "1"
+version = "2"
 features = ["vector"]
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ license     = "Apache-2.0 OR MIT"
 repository  = "https://github.com/NeoBirth/accelerometer.rs"
 readme      = "README.md"
 edition     = "2018"
+rust-version = "1.47"
 categories  = ["embedded", "hardware-support", "no-std"]
 keywords    = ["acceleration", "position", "tracking"]
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ accelerometer data.
 
 ## Requirements
 
-- Rust 1.31+
+- Rust 1.47+
 
 ## Supported Crates
 

--- a/src/accelerometer.rs
+++ b/src/accelerometer.rs
@@ -39,7 +39,7 @@ pub trait Accelerometer {
 ///
 /// This is intended to provide direct access to raw accelerometer data and
 /// should use a vector type which best matches the raw accelerometer data.
-pub trait RawAccelerometer<C: Component, V: Vector<C>>{
+pub trait RawAccelerometer<C: Component, V: Vector<C>> {
     /// Error type
     type Error: Debug;
 

--- a/src/accelerometer.rs
+++ b/src/accelerometer.rs
@@ -1,5 +1,7 @@
 //! Traits for reading acceleration measurements from accelerometers.
 
+use micromath::vector::Component;
+
 use crate::{
     error::Error,
     vector::{F32x3, Vector},
@@ -37,7 +39,7 @@ pub trait Accelerometer {
 ///
 /// This is intended to provide direct access to raw accelerometer data and
 /// should use a vector type which best matches the raw accelerometer data.
-pub trait RawAccelerometer<V: Vector> {
+pub trait RawAccelerometer<C: Component, V: Vector<C>>{
     /// Error type
     type Error: Debug;
 

--- a/src/orientation.rs
+++ b/src/orientation.rs
@@ -32,25 +32,16 @@ pub enum Orientation {
 impl Orientation {
     /// Is this orientation considered to be flat?
     pub fn is_flat(self) -> bool {
-        match self {
-            Orientation::FaceUp | Orientation::FaceDown => true,
-            _ => false,
-        }
+        matches!(self, Orientation::FaceUp | Orientation::FaceDown)
     }
 
     /// Is the device in a landscape orientation?
     pub fn is_landscape(self) -> bool {
-        match self {
-            Orientation::LandscapeUp | Orientation::LandscapeDown => true,
-            _ => false,
-        }
+        matches!(self, Orientation::LandscapeUp | Orientation::LandscapeDown)
     }
 
     /// Is the device in a portrait orientation?
     pub fn is_portrait(self) -> bool {
-        match self {
-            Orientation::PortraitUp | Orientation::PortraitDown => true,
-            _ => false,
-        }
+        matches!(self, Orientation::PortraitUp | Orientation::PortraitDown)
     }
 }

--- a/src/orientation/tracker.rs
+++ b/src/orientation/tracker.rs
@@ -2,9 +2,8 @@
 
 use crate::{
     orientation::Orientation,
-    vector::{Component, Vector, VectorExt},
+    vector::{Component, Vector3d},
 };
-use micromath::generic_array::typenum::U3;
 
 // Used for intra-doc-link resolution only
 #[allow(unused_imports)]
@@ -45,9 +44,8 @@ impl Tracker {
     /// Update the tracker's internal state from the given acceleration vector
     /// (i.e. obtained from [`Accelerometer::accel_norm`]), returning a new
     /// computed orientation value.
-    pub fn update<V, C>(&mut self, acceleration: V) -> Orientation
+    pub fn update<C>(&mut self, acceleration: Vector3d<C>) -> Orientation
     where
-        V: Vector<Axes = U3, Component = C> + VectorExt,
         C: Component + Into<f32>,
     {
         let components = acceleration.to_array();


### PR DESCRIPTION
To upgrade to `micromath` v2.0, few minimal changes were needed to comply with the refactored vector types.