### PR TITLE
Add defmt support and highlight crate features in docs.rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,9 @@ keywords    = ["acceleration", "position", "tracking"]
 [badges]
 maintenance = { status = "passively-maintained" }
 
+[dependencies]
+defmt = { version = "0.3.8", optional = true }
+
 [dependencies.micromath]
 version = "2"
 features = ["vector"]
@@ -25,3 +28,6 @@ features = ["vector"]
 [features]
 default = ["orientation"]
 orientation = []
+
+[package.metadata.docs.rs]
+rustdoc-args = ["--cfg", "docsrs"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,33 +1,36 @@
 [package]
-name        = "accelerometer"
-version     = "0.12.0" # Also update html_root_url in lib.rs when bumping this
+name = "accelerometer"
+version = "0.12.0" # Also update html_root_url in lib.rs when bumping this
 description = """
 Generic, embedded-friendly accelerometer support, including
 traits and types for taking readings from 2 or 3-axis
 accelerometers and tracking device orientations.
 """
-authors     = ["Tony Arcieri <bascule@gmail.com>"]
-license     = "Apache-2.0 OR MIT"
-repository  = "https://github.com/NeoBirth/accelerometer.rs"
-readme      = "README.md"
-edition     = "2018"
+authors = ["Tony Arcieri <bascule@gmail.com>"]
+license = "Apache-2.0 OR MIT"
+repository = "https://github.com/NeoBirth/accelerometer.rs"
+readme = "README.md"
+edition = "2018"
 rust-version = "1.47"
-categories  = ["embedded", "hardware-support", "no-std"]
-keywords    = ["acceleration", "position", "tracking"]
+categories = ["embedded", "hardware-support", "no-std"]
+keywords = ["acceleration", "position", "tracking"]
 
 [badges]
 maintenance = { status = "passively-maintained" }
-
-[dependencies]
-defmt = { version = "0.3.8", optional = true }
 
 [dependencies.micromath]
 version = "2"
 features = ["vector"]
 
+[dependencies.defmt]
+version = "0.3.8"
+optional = true
+
 [features]
 default = ["orientation"]
 orientation = []
+defmt = ["dep:defmt"]
 
 [package.metadata.docs.rs]
+all-features = true
 rustdoc-args = ["--cfg", "docsrs"]

--- a/src/error.rs
+++ b/src/error.rs
@@ -100,3 +100,39 @@ where
         Self::new_with_cause(ErrorKind::Bus, cause)
     }
 }
+
+#[cfg_attr(docsrs, doc(cfg(feature = "defmt")))]
+#[cfg(feature = "defmt")]
+impl<E: Debug + defmt::Format> defmt::Format for Error<E> {
+    fn format(&self, fmt: defmt::Formatter<'_>) {
+        // Implemented manually so that the docs.rs marker can be applied.
+        defmt::write!(
+            fmt,
+            "Error {{ kind = {}, cause = {}  }}",
+            self.kind,
+            self.cause
+        )
+    }
+}
+
+#[cfg_attr(docsrs, doc(cfg(feature = "defmt")))]
+#[cfg(feature = "defmt")]
+impl defmt::Format for ErrorKind {
+    fn format(&self, fmt: defmt::Formatter<'_>) {
+        // Implemented manually so that the docs.rs marker can be applied.
+        match self {
+            ErrorKind::Device => {
+                defmt::write!(fmt, "Device")
+            }
+            ErrorKind::Bus => {
+                defmt::write!(fmt, "Bus")
+            }
+            ErrorKind::Mode => {
+                defmt::write!(fmt, "Mode")
+            }
+            ErrorKind::Param => {
+                defmt::write!(fmt, "Param")
+            }
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,8 +39,12 @@
 #![forbid(unsafe_code)]
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
 
+// Enables the `doc_cfg` feature when the `docsrs` configuration attribute is defined.
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
 mod accelerometer;
 pub mod error;
+#[cfg_attr(docsrs, doc(cfg(feature = "orientation")))]
 #[cfg(feature = "orientation")]
 pub mod orientation;
 

--- a/src/orientation.rs
+++ b/src/orientation.rs
@@ -45,3 +45,34 @@ impl Orientation {
         matches!(self, Orientation::PortraitUp | Orientation::PortraitDown)
     }
 }
+
+#[cfg_attr(docsrs, doc(cfg(feature = "defmt")))]
+#[cfg(feature = "defmt")]
+impl defmt::Format for Orientation {
+    fn format(&self, fmt: defmt::Formatter<'_>) {
+        // Implemented manually so that the docs.rs marker can be applied.
+        match self {
+            Orientation::Unknown => {
+                defmt::write!(fmt, "Unknown")
+            }
+            Orientation::PortraitUp => {
+                defmt::write!(fmt, "PortraitUp")
+            }
+            Orientation::PortraitDown => {
+                defmt::write!(fmt, "PortraitDown")
+            }
+            Orientation::LandscapeUp => {
+                defmt::write!(fmt, "LandscapeUp")
+            }
+            Orientation::LandscapeDown => {
+                defmt::write!(fmt, "LandscapeDown")
+            }
+            Orientation::FaceUp => {
+                defmt::write!(fmt, "FaceUp")
+            }
+            Orientation::FaceDown => {
+                defmt::write!(fmt, "FaceDown")
+            }
+        }
+    }
+}

--- a/src/orientation/tracker.rs
+++ b/src/orientation/tracker.rs
@@ -92,3 +92,17 @@ impl Tracker {
         self.last_orientation
     }
 }
+
+#[cfg_attr(docsrs, doc(cfg(feature = "defmt")))]
+#[cfg(feature = "defmt")]
+impl defmt::Format for Tracker {
+    fn format(&self, fmt: defmt::Formatter<'_>) {
+        // Implemented manually so that the docs.rs marker can be applied.
+        defmt::write!(
+            fmt,
+            "Tracker {{ threshold = {}, last_orientation = {}  }}",
+            self.threshold,
+            self.last_orientation
+        )
+    }
+}


### PR DESCRIPTION
This adds support for [defmt](https://defmt.ferrous-systems.com/) via the `defmt` feature flag. This mainly brings defmt to the error types, but also adds it to `Orientation`.

To improve documentation, I added a rustdoc conditional feature for highlighting gated feature. All of the `defmt::Format` implementations could have been simply derived with a `cfg_attr`, but it doesn't work smoothly with the `#[cfg_attr(docsrs, doc(...))]` annotation.

To test documentation, you can run:

```shell
RUSTDOCFLAGS='--cfg docsrs' cargo +nightly doc --open --all-features
````

It should render like this:

![image](https://github.com/NeoBirth/accelerometer.rs/assets/495335/d65da74e-ee48-4371-85b4-af7455af7ceb)
